### PR TITLE
Allow to use external/self-managed Postgres and Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ helm install patchmon oci://ghcr.io/ruthlessbeat200/charts/patchmon \
 | `database.enabled` | Enable PostgreSQL deployment | `true` |
 | `database.image.repository` | PostgreSQL image repository | `postgres` |
 | `database.image.tag` | PostgreSQL image tag | `18-alpine` |
+| `database.host` | Database host | `nil` |
+| `database.port` | Database port | `nil` |
 | `database.auth.database` | Database name | `patchmon_db` |
 | `database.auth.username` | Database user | `patchmon_user` |
 | `database.auth.password` | Database password (**must be set or use existingSecret**) | `""` |

--- a/templates/backend-deployment.yaml
+++ b/templates/backend-deployment.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.backend.enabled -}}
+{{- $databaseHost := .Values.database.host | default (print (include "patchmon.fullname" .) "-database") }}
+{{- $databasePort := .Values.database.port | default .Values.database.service.port }}
+{{- $redisHost := .Values.backend.env.redisHost | default (print (include "patchmon.fullname" .) "-redis") }}
+{{- $redisPort := .Values.backend.env.redisPort | default .Values.redis.service.port }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -45,7 +49,7 @@ spec:
           command:
             - sh
             - "-c"
-            - "until nc -z {{ include "patchmon.fullname" . }}-database {{ .Values.database.service.port }}; do echo waiting for database; sleep 2; done"
+            - "until nc -z {{ $databaseHost }} {{ $databasePort }}; do echo waiting for database; sleep 2; done"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -60,7 +64,7 @@ spec:
           command:
             - sh
             - "-c"
-            - "until nc -z {{ include "patchmon.fullname" . }}-redis {{ .Values.redis.service.port }}; do echo waiting for redis; sleep 2; done"
+            - "until nc -z {{ $redisHost }} {{ $redisPort }}; do echo waiting for redis; sleep 2; done"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -106,7 +110,7 @@ spec:
                   name: {{ include "patchmon.database.secretName" . }}
                   key: {{ .Values.database.auth.existingSecretPasswordKey }}
             - name: DATABASE_URL
-              value: "postgresql://{{ .Values.database.auth.username }}:$(POSTGRES_PASSWORD)@{{ include "patchmon.fullname" . }}-database:{{ .Values.database.service.port }}/{{ .Values.database.auth.database }}"
+              value: "postgresql://{{ .Values.database.auth.username }}:$(POSTGRES_PASSWORD)@{{ $databaseHost }}:{{ $databasePort }}/{{ .Values.database.auth.database }}"
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -155,9 +159,9 @@ spec:
             - name: AGENT_RATE_LIMIT_MAX
               value: {{ .Values.backend.env.agentRateLimitMax | quote }}
             - name: REDIS_HOST
-              value: {{ include "patchmon.fullname" . }}-redis
+              value: {{ $redisHost | quote }}
             - name: REDIS_PORT
-              value: {{ .Values.redis.service.port | quote }}
+              value: {{ $redisPort | quote }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -33,6 +33,9 @@ database:
     tag: "18-alpine"
     pullPolicy: IfNotPresent
   
+  # host: ""
+  # port: 5432
+  
   # Database credentials
   auth:
     database: patchmon_db
@@ -257,6 +260,8 @@ backend:
     agentRateLimitWindowMs: "60000"
     agentRateLimitMax: "1000"
     # Redis configuration
+    # redisHost: ""
+    # redisPort: "6379"
     redisDb: "0"
     # Security
     # Trust proxy headers from ingress controller and internal cluster networks


### PR DESCRIPTION
For binding to an external/self-managed Postgres database use:
```
database:
  enabled: false
  host: postgres.example.com
  port: 5432
  auth:
    username: patchmon_user
    password: *****
    database: patchmon_db
```
For binding to an external/self-managed Redis use:
```
redis:
  enabled: false

backend:
  env:
    redisHost: redis.example.com
    redisPort: "6379"
```