### PR TITLE
Allow specifying service annotations and topology spread constraints

### DIFF
--- a/templates/backend-deployment.yaml
+++ b/templates/backend-deployment.yaml
@@ -282,4 +282,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.backend.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/templates/backend-service.yaml
+++ b/templates/backend-service.yaml
@@ -6,9 +6,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "patchmon.backend.labels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
+  {{- if or .Values.backend.service.annotations .Values.commonAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- with .Values.backend.service.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.commonAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.backend.service.type }}

--- a/templates/frontend-deployment.yaml
+++ b/templates/frontend-deployment.yaml
@@ -107,4 +107,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.frontend.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/templates/frontend-service.yaml
+++ b/templates/frontend-service.yaml
@@ -6,9 +6,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "patchmon.frontend.labels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
+  {{- if or .Values.frontend.service.annotations .Values.commonAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- with .Values.frontend.service.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.commonAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.frontend.service.type }}

--- a/values.yaml
+++ b/values.yaml
@@ -329,6 +329,7 @@ backend:
   
   # Service configuration
   service:
+    annotations: []
     type: ClusterIP
     port: 3001
   
@@ -372,6 +373,9 @@ backend:
   
   # Affinity
   affinity: {}
+  
+  # Topology spread constraints
+  topologySpreadConstraints: []
 
 # Frontend configuration
 frontend:
@@ -427,6 +431,7 @@ frontend:
   
   # Service configuration
   service:
+    annotations: []
     type: ClusterIP
     port: 3000
   
@@ -463,6 +468,9 @@ frontend:
   
   # Affinity
   affinity: {}
+  
+  # Topology spread constraints
+  topologySpreadConstraints: []
 
 # Ingress configuration
 ingress:


### PR DESCRIPTION
You can now specify additional frontend and backend service annotations as well as topology spread constraints for the frontend and backend deployment.